### PR TITLE
chore: Add Get-MoviesFromCsv function and tests

### DIFF
--- a/shell.Tests.ps1
+++ b/shell.Tests.ps1
@@ -1,0 +1,62 @@
+Describe "Get-MoviesFromCsv" {
+    Context "When CSV file path is provided" {
+        It "Should return all movies from the CSV file" {
+            # Arrange
+            $csvFilePath = "C:\path\to\movies.csv"
+
+            # Act
+            $result = Get-MoviesFromCsv -CsvFilePath $csvFilePath
+
+            # Assert
+            $result | Should -Contain "Movie 1 (2021)"
+            $result | Should -Contain "Movie 2 (2022)"
+            $result | Should -Contain "Movie 3 (2023)"
+        }
+    }
+
+    Context "When CSV file path and year are provided" {
+        It "Should return movies from the specified year" {
+            # Arrange
+            $csvFilePath = "C:\path\to\movies.csv"
+            $year = 2022
+
+            # Act
+            $result = Get-MoviesFromCsv -CsvFilePath $csvFilePath -Year $year
+
+            # Assert
+            $result | Should -Contain "Movie 2 (2022)"
+        }
+    }
+}
+
+Describe "Get-MoviesFromCsv" {
+    Context "When CsvFilePath is provided" {
+        It "Should return movies from the CSV file" {
+            # Arrange
+            $csvFilePath = "C:\path\to\movies.csv"
+
+            # Act
+            $result = Get-MoviesFromCsv -CsvFilePath $csvFilePath
+
+            # Assert
+            $result | Should -Contain "Movie 1 (2021)"
+            $result | Should -Contain "Movie 2 (2022)"
+            # Add more assertions for other movies in the CSV file
+        }
+    }
+
+    Context "When CsvFilePath and Year are provided" {
+        It "Should return movies from the CSV file that match the specified year" {
+            # Arrange
+            $csvFilePath = "C:\path\to\movies.csv"
+            $year = 2021
+
+            # Act
+            $result = Get-MoviesFromCsv -CsvFilePath $csvFilePath -Year $year
+
+            # Assert
+            $result | Should -Contain "Movie 1 (2021)"
+            # Add more assertions for other movies in the CSV file that match the specified year
+        }
+    }
+}

--- a/shell.ps1
+++ b/shell.ps1
@@ -1,0 +1,20 @@
+function Get-MoviesFromCsv {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$CsvFilePath,
+
+        [Parameter(Mandatory=$false)]
+        [int]$Year
+    )
+
+    $movies = Import-Csv -Path $CsvFilePath
+
+    if ($Year) {
+        $movies = $movies | Where-Object { $_.Year -eq $Year }
+    }
+
+    foreach ($movie in $movies) {
+        Write-Output "$($movie.Film) ($($movie.Year))"
+    }
+}


### PR DESCRIPTION
This pull request introduces a new functionality to the PowerShell script, enabling it to read and filter movies from a CSV file. The most important changes include the addition of a new function `Get-MoviesFromCsv` in `shell.ps1` and corresponding test cases in `shell.Tests.ps1`.

New Functionality:

* [`shell.ps1`](diffhunk://#diff-adb07f2f5f8e5a2089d4eddd2df19627e652a17138ff8d02a4200756f61b5ccbR1-R20): Added a new function `Get-MoviesFromCsv` that takes a CSV file path and an optional year as parameters. This function reads the CSV file, filters the movies by the provided year (if any), and outputs the movie names along with their release years.

Test Cases:

* [`shell.Tests.ps1`](diffhunk://#diff-7b39879ee69733447646be87b180897d10eeef211e1a169a8477af9a4156d87fR1-R62): Added test cases for the new `Get-MoviesFromCsv` function. The tests cover two scenarios: when only the CSV file path is provided and when both the CSV file path and year are provided. In the first scenario, the test checks if all movies from the CSV file are returned. In the second scenario, it checks if only the movies from the specified year are returned.